### PR TITLE
Update ursa package to 0.9 in order to build for Node 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "js-yaml": "^3.3.0",
     "lodash": "^3.2.0",
     "node.extend": "^1.1.3",
-    "ursa": "=0.8.3"
+    "ursa": "^0.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm running Node 4.1 with NVM and the module won't build with Ursa specified as v0.8.  Updated package.json and all tests are passing.
